### PR TITLE
Added support to use placeholders on kafka-listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The library doesn't handle topics creation.
     <jackson.version>2.9.5</jackson.version>
     <spring-boot.version>1.5.12.RELEASE</spring-boot.version>
     <spring-kafka.version>1.3.5.RELEASE</spring-kafka.version>
-    <spring-kafka-retry.version>1.0.0.RELEASE</spring-kafka-retry.version>
+    <spring-kafka-retry.version>1.0.1</spring-kafka-retry.version>
 </properties>
 
 <dependencies>

--- a/src/main/kotlin/io/zup/springframework/kafka/annotation/BackOffStrategy.kt
+++ b/src/main/kotlin/io/zup/springframework/kafka/annotation/BackOffStrategy.kt
@@ -4,7 +4,7 @@ import java.time.Clock
 import java.util.*
 import kotlin.math.pow
 
-enum class BackoffStrategy {
+enum class BackOffStrategy {
 
     CONSTANT {
         override fun calculateBackoffTimeInSeconds(clock: Clock, iteration: Int, timeInterval: Long): Long =

--- a/src/main/kotlin/io/zup/springframework/kafka/annotation/RetryAwareKafkaListenerAnnotationBeanPostProcessor.kt
+++ b/src/main/kotlin/io/zup/springframework/kafka/annotation/RetryAwareKafkaListenerAnnotationBeanPostProcessor.kt
@@ -2,6 +2,7 @@ package io.zup.springframework.kafka.annotation
 
 import io.zup.springframework.kafka.listener.KafkaRetryPolicyErrorHandler
 import org.springframework.core.annotation.AnnotationUtils
+import org.springframework.core.env.Environment
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.annotation.KafkaListenerAnnotationBeanPostProcessor
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint
@@ -9,9 +10,9 @@ import org.springframework.kafka.core.KafkaTemplate
 import java.lang.reflect.Method
 
 open class RetryAwareKafkaListenerAnnotationBeanPostProcessor<K, V>(
-    val template: KafkaTemplate<K, V>
+    val template: KafkaTemplate<K, V>,
+    val environment: Environment
 ) : KafkaListenerAnnotationBeanPostProcessor<K, V>() {
-
 
     override fun processListener(
         endpoint: MethodKafkaListenerEndpoint<*, *>?,
@@ -32,7 +33,7 @@ open class RetryAwareKafkaListenerAnnotationBeanPostProcessor<K, V>(
 
     private fun setErrorHandler(bean: Any, endpoint: MethodKafkaListenerEndpoint<*, *>) =
         retryPolicyFor(bean, endpoint.method)
-            ?.let { KafkaRetryPolicyErrorHandler.from(it, template) }
+            ?.let { KafkaRetryPolicyErrorHandler.from(it, template, environment) }
             ?.let { endpoint.setErrorHandler(it) }
 
     private fun retryPolicyFor(bean: Any, method: Method): RetryPolicy? =

--- a/src/main/kotlin/io/zup/springframework/kafka/annotation/RetryPolicy.kt
+++ b/src/main/kotlin/io/zup/springframework/kafka/annotation/RetryPolicy.kt
@@ -6,5 +6,5 @@ annotation class RetryPolicy(
     val retries: Int,
     val dlqTopic: String,
     val retryInterval: Long = 1L,
-    val backoffStrategy: BackoffStrategy = BackoffStrategy.EXPONENTIAL
+    val backoffStrategy: BackOffStrategy = BackOffStrategy.EXPONENTIAL
 )

--- a/src/main/kotlin/io/zup/springframework/kafka/config/KafkaRetryConfiguration.kt
+++ b/src/main/kotlin/io/zup/springframework/kafka/config/KafkaRetryConfiguration.kt
@@ -4,6 +4,7 @@ import io.zup.springframework.kafka.annotation.RetryAwareKafkaListenerAnnotation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
 import org.springframework.kafka.config.KafkaListenerConfigUtils
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry
 import org.springframework.kafka.core.KafkaTemplate
@@ -14,12 +15,15 @@ open class KafkaRetryConfiguration {
     @Autowired
     private lateinit var kafkaTemplate: KafkaTemplate<Any, Any>
 
+    @Autowired
+    private lateinit var environment: Environment
+
     @Bean(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
     open fun defaultKafkaListenerEndpointRegistry(): KafkaListenerEndpointRegistry =
         KafkaListenerEndpointRegistry()
 
     @Bean(KafkaListenerConfigUtils.KAFKA_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME)
     open fun retryAwareKafkaListenerAnnotationBeanPostProcessor(): RetryAwareKafkaListenerAnnotationBeanPostProcessor<*, *> =
-        RetryAwareKafkaListenerAnnotationBeanPostProcessor(kafkaTemplate)
+        RetryAwareKafkaListenerAnnotationBeanPostProcessor(kafkaTemplate, environment)
 
 }

--- a/src/test/kotlin/io/zup/springframework/kafka/annotation/BackoffStrategyTest.kt
+++ b/src/test/kotlin/io/zup/springframework/kafka/annotation/BackoffStrategyTest.kt
@@ -22,7 +22,7 @@ class BackoffStrategyTest {
     fun `should calculate backoff time in seconds considering a constant progression`() {
 
         repeat(10) {
-            val calculatedValue = BackoffStrategy.CONSTANT.calculateBackoffTimeInSeconds(clock, it, INTERVAL)
+            val calculatedValue = BackOffStrategy.CONSTANT.calculateBackoffTimeInSeconds(clock, it, INTERVAL)
             assertEquals(INTERVAL, calculatedValue)
         }
     }
@@ -31,7 +31,7 @@ class BackoffStrategyTest {
     fun `should calculate backoff time in seconds considering a linear progression`() {
 
         repeat(10) {
-            val calculatedValue = BackoffStrategy.LINEAR.calculateBackoffTimeInSeconds(clock, it, INTERVAL)
+            val calculatedValue = BackOffStrategy.LINEAR.calculateBackoffTimeInSeconds(clock, it, INTERVAL)
             assertEquals((it + 1) * INTERVAL, calculatedValue)
         }
     }
@@ -40,7 +40,7 @@ class BackoffStrategyTest {
     fun `should calculate backoff time in seconds considering a exponential progression`() {
 
         repeat(10) {
-            val calculatedValue = BackoffStrategy.EXPONENTIAL.calculateBackoffTimeInSeconds(clock, it, INTERVAL)
+            val calculatedValue = BackOffStrategy.EXPONENTIAL.calculateBackoffTimeInSeconds(clock, it, INTERVAL)
             assertEquals((2.0.pow(it) * INTERVAL).toLong(), calculatedValue)
         }
     }
@@ -49,7 +49,7 @@ class BackoffStrategyTest {
     fun `should calculate backoff time in seconds considering a random progression`() {
 
         repeat(10) {
-            val calculatedValue = BackoffStrategy.RANDOM.calculateBackoffTimeInSeconds(clock, it, INTERVAL)
+            val calculatedValue = BackOffStrategy.RANDOM.calculateBackoffTimeInSeconds(clock, it, INTERVAL)
             assertThat(calculatedValue, greaterThanOrEqualTo(0L))
             assertThat(calculatedValue, lessThan((it + 1) * INTERVAL))
         }

--- a/src/test/kotlin/io/zup/springframework/kafka/config/KafkaTestConfiguration.kt
+++ b/src/test/kotlin/io/zup/springframework/kafka/config/KafkaTestConfiguration.kt
@@ -66,7 +66,7 @@ open class KafkaTestConfiguration {
             retryTopic = TestConstants.RETRY_TOPIC,
             retryInterval = TestConstants.RETRY_INTERVAL,
             dlqTopic = TestConstants.DLQ_TOPIC,
-            backoffStrategy = TestConstants.BACKOFF_STRATEGY,
+            backOffStrategy = TestConstants.BACKOFF_STRATEGY,
             clock = clock()
         )
 }

--- a/src/test/kotlin/io/zup/springframework/kafka/helper/TestConstants.kt
+++ b/src/test/kotlin/io/zup/springframework/kafka/helper/TestConstants.kt
@@ -1,6 +1,6 @@
 package io.zup.springframework.kafka.helper
 
-import io.zup.springframework.kafka.annotation.BackoffStrategy
+import io.zup.springframework.kafka.annotation.BackOffStrategy
 import java.time.Instant
 
 object TestConstants {
@@ -17,6 +17,6 @@ object TestConstants {
 
     val BASE_INSTANT = Instant.parse("1986-07-05T09:00:00Z")
 
-    val BACKOFF_STRATEGY = BackoffStrategy.CONSTANT
+    val BACKOFF_STRATEGY = BackOffStrategy.CONSTANT
 
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 logging.level.root=DEBUG
 
 spring.kafka.consumer.auto-offset-reset=latest
+kafka.main.topic=main-topic


### PR DESCRIPTION
The current version is not accepting using placeholders via application.properties to resolve the topics name:

```kotlin
    @RetryPolicy(
        id = RETRY_POLICY_ID,
        topic = "\${kafka.retry.topic}",
        dlqTopic = "\${kafka.dlq.topic}",
        retries = 3
    )
    @KafkaListener(topics = ["\${kafka.topic}"])
    override fun onListen(message: String) {
        // Do something
    }
```

This PR solves this issue.